### PR TITLE
Fixed import issues; patch version may be different now

### DIFF
--- a/avrpy/__init__.py
+++ b/avrpy/__init__.py
@@ -1,2 +1,2 @@
-from constants import *
-from avr_bits import *
+from .constants import *
+from .avr_bits import *

--- a/avrpy/__version__.py
+++ b/avrpy/__version__.py
@@ -8,7 +8,7 @@ __title__ = "avrpy"
 __description__ = (
     "Low-level control of an AVR microcontroller using Python via serial port."
 )
-__version__ = "0.1.0"  # MUST be the same as in `firmware.ino`
+__version__ = "0.1.1"  # Major and minor MUST be the same as in `firmware.ino`, patch may be different
 __author__ = "Roman Kiselev"
 __author_email__ = "roman.kiselev@stjude.org"
 __license__ = "Apache 2.0"

--- a/avrpy/avr_base.py
+++ b/avrpy/avr_base.py
@@ -1,8 +1,9 @@
 import serial
-from time import sleep
 from enum import Enum
-from constants import ms, MHz
-from __version__ import __version__
+from time import sleep
+from . __version__ import __version__
+from . constants import ms, MHz
+
 
 class RegisterBase(Enum):
     """
@@ -19,6 +20,11 @@ class RegisterBase(Enum):
     @property
     def addr(self):
         return self.value[0]
+
+
+def _compare_versions(v1, v2):
+    return {k: a == b for k, a, b in zip(["major", "minor", "patch"], v1.split("."), v2.split("."))}
+
 
 class AVR_Base(object):
     """
@@ -45,7 +51,9 @@ class AVR_Base(object):
                     f"Received message:\n{msg}\n" +
                     f"Expected message:\n{msg_template + __version__}")
             v = msg[len(msg_template):]
-            if v != __version__:
+
+            version_match = _compare_versions(v, __version__)
+            if not version_match["major"] or not version_match["minor"]:
                 raise RuntimeWarning(f"Version mismatch: driver {__version__} != firmware {v}")
 
         self.serial.flush()

--- a/avrpy/mega328P.py
+++ b/avrpy/mega328P.py
@@ -1,4 +1,4 @@
-from avr_base import define_AVR, RegisterBase
+from . avr_base import define_AVR, RegisterBase
 
 """
 ATmega328P registers, adapted from

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
-from mega328P import Mega328P
-from constants import *
-from avr_bits import *
+from avrpy.mega328P import Mega328P
+from avrpy import *
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The version consists of <major>.<minor>.<patch>. When we connect to the MCU, we check only <major> and <minor>, the patch is ignored from now on.